### PR TITLE
#11 Fixing #4

### DIFF
--- a/system.go
+++ b/system.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"os/exec"
+	b64 "encoding/base64"
 
 	"golang.org/x/crypto/sha3"
 )
@@ -22,7 +23,7 @@ func runCmd(sh string,args ...string){
 func hashThese(b []byte) string {
 	hash := make([]byte, 64)
 	sha3.ShakeSum256(hash, b)
-	return string(hash)
+	return b64.StdEncoding.EncodeToString(hash)
 }
 
 func hashFile(p string) string {

--- a/toml.go
+++ b/toml.go
@@ -149,10 +149,10 @@ func (p Package) build() {
 	for _, item := range manifest {
 		hash := hashFile(item)
 		truePath := strings.Split(item, binpath)[1]
-		manifestFile.Write([]byte(truePath + " " + hash))
+		manifestFile.Write([]byte(truePath + " " + hash + "\n"))
 	}
 	manifest = append(manifest,manifestPath + "/manifest")
-	manifestFile.Write([]byte(manifestPath + "/manifest"+ " " + hashFile(manifestPath + "/manifest")))
+	manifestFile.Write([]byte(manifestPath + "/manifest"+ " " + hashFile(manifestPath + "/manifest")+ "\n"))
 
 	// this will execute postscript
 	// if available
@@ -204,7 +204,7 @@ func (p Package) remove(){
 	scan.Split(bufio.ScanLines)
 
 	for scan.Scan(){
-		os.Remove(os.Getenv("KARTINI_ROOT") +"/" + splitStr(scan.Text()," ")[0])
+		os.RemoveAll(os.Getenv("KARTINI_ROOT") +"/" + splitStr(scan.Text()," ")[0])
 	}
 }
 


### PR DESCRIPTION
SHA3 binary need converted to base64 to avoid bad-chars, and add newline when write index on manifest files.